### PR TITLE
Update WordPress test suite to 5.3

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -4,4 +4,4 @@ PHPUNIT_CONFIG=phpunit.xml.dist
 DOCKER_PHPUNIT_BIN=bin/phpunit
 DOCKER_WORKDIR=/app/wp-content/plugins/wporg-tide-api
 DOCKER_IMAGE=api-php
-WP_VERSION=4.9.8
+WP_VERSION=5.2.3

--- a/.dev-lib
+++ b/.dev-lib
@@ -4,4 +4,4 @@ PHPUNIT_CONFIG=phpunit.xml.dist
 DOCKER_PHPUNIT_BIN=bin/phpunit
 DOCKER_WORKDIR=/app/wp-content/plugins/wporg-tide-api
 DOCKER_IMAGE=api-php
-WP_VERSION=5.2.3
+WP_VERSION=5.3.0


### PR DESCRIPTION
Relates to wptide/wp-tide-api#29.
One of many PRs to close wptide/wptide#177.